### PR TITLE
Fix issue #22

### DIFF
--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -657,6 +657,7 @@ class _SettingsColorPicker extends StatelessWidget {
       enabled: enabled,
       onTap: () => _showColorPicker(context, value),
       child: FloatingActionButton(
+        heroTag: null,
         backgroundColor: Utils.colorFromString(value),
         elevation: 0,
         onPressed: enabled ? () => _showColorPicker(context, value) : null,


### PR DESCRIPTION
Set heroTag of FloatingActionButton to null to avoid exception when several ColorPickerSettingsTile are used