### PR TITLE
Conditional value change

### DIFF
--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -1392,7 +1392,7 @@ class SwitchSettingsTile extends StatelessWidget {
     );
   }
 
-  void _onSwitchChange(bool value, OnChanged<bool> onChanged) async {
+  void _onSwitchChange(bool value, OnChanged<bool> onChanged) {
     onChanged(value);
     if (onChange != null) {
       onChange(value);

--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -1885,15 +1885,12 @@ class _SliderSettingsTileState extends State<SliderSettingsTile> {
               leading: widget.leading,
             ),
             _SettingsSlider(
-              onChanged: (newValue) {
-                _handleSliderChanged(newValue, onChanged);
-              },
-              onChangeStart: (newValue) {
-                _handleSliderChangeStart(newValue, onChanged);
-              },
-              onChangeEnd: (newValue) {
-                _handleSliderChangeEnd(newValue, onChanged);
-              },
+              onChanged: (newValue) =>
+                  _handleSliderChanged(newValue, onChanged),
+              onChangeStart: (newValue) =>
+                  _handleSliderChangeStart(newValue, onChanged),
+              onChangeEnd: (newValue) =>
+                  _handleSliderChangeEnd(newValue, onChanged),
               enabled: widget.enabled,
               value: value,
               max: widget.max,
@@ -2002,9 +1999,7 @@ class _ColorPickerSettingsTileState extends State<ColorPickerSettingsTile> {
           title: widget.title,
           value: value,
           enabled: widget.enabled,
-          onChanged: (color) {
-            _handleColorChanged(color, onChanged);
-          },
+          onChanged: (color) => _handleColorChanged(color, onChanged),
         );
       },
     );
@@ -2200,15 +2195,12 @@ class _SliderModalSettingsTileState extends State<SliderModalSettingsTile> {
                   : value.toString(),
               children: <Widget>[
                 _SettingsSlider(
-                  onChanged: (double newValue) {
-                    _handleSliderChanged(newValue, onChanged);
-                  },
-                  onChangeStart: (double newValue) {
-                    _handleSliderChangeStart(newValue, onChanged);
-                  },
-                  onChangeEnd: (double newValue) {
-                    _handleSliderChangeEnd(newValue, onChanged);
-                  },
+                  onChanged: (double newValue) =>
+                      _handleSliderChanged(newValue, onChanged),
+                  onChangeStart: (double newValue) =>
+                      _handleSliderChangeStart(newValue, onChanged),
+                  onChangeEnd: (double newValue) =>
+                      _handleSliderChangeEnd(newValue, onChanged),
                   enabled: widget.enabled,
                   value: value,
                   max: widget.max,


### PR DESCRIPTION
Firstly, thank you for the package! It has been a great help at the beginning of our project.

In a later phase of our project, we've stumbled upon a missing feature _conditional changing of the widget's value_. To be more precise, we use a `SwitchSettingsTile` to manage in-app permissions including the initial request for these permissions. 
After a user hits the switch we ask him for his permission for the feature and based on the result of the request we want to adjust the widget's value. Currently, when the user denies the permission, the `SwitchSettingsTile`'s value still changes from `false` (initial value) to `true` even though the user declines these permissions.

As a suggested solution, we have added an optional `value` parameter to some widgets where conditional value changes could become handy. This way we can handle the state from within the parent widget.

We are unsure if the suggested solution fits your intentions for the package and the coding style you've used. We'd appreciate it if you would take the time to review the PR and if desired propose a solution that is ok with you.