### PR TITLE
Confirmation before applying to storage

### DIFF
--- a/example/lib/app_settings_page.dart
+++ b/example/lib/app_settings_page.dart
@@ -27,6 +27,13 @@ class _AppSettingsState extends State<AppSettings> {
                 onChange: (value) {
                   debugPrint('key-wifi: $value');
                 },
+                confirmChangeCallback: () async {
+                  var confirmChange = await showConfirmationDialog(
+                      context: context,
+                      confirmationMessage:
+                          'Do you really want to change this?');
+                  return confirmChange;
+                },
               ),
               CheckboxSettingsTile(
                 settingKey: 'key-blue-tooth',
@@ -38,6 +45,13 @@ class _AppSettingsState extends State<AppSettings> {
                 leading: Icon(Icons.bluetooth),
                 onChange: (value) {
                   debugPrint('key-blue-tooth: $value');
+                },
+                confirmChangeCallback: () async {
+                  var confirmChange = await showConfirmationDialog(
+                      context: context,
+                      confirmationMessage:
+                      'Do you really want to change this?');
+                  return confirmChange;
                 },
               ),
               SwitchSettingsTile(
@@ -89,6 +103,13 @@ class _AppSettingsState extends State<AppSettings> {
                       onChange: (bool value) {
                         debugPrint('Developer Mode ${value ? 'on' : 'off'}');
                       },
+                      confirmChangeCallback: () async {
+                        var confirmChange = await showConfirmationDialog(
+                            context: context,
+                            confirmationMessage:
+                            'Do you really want to change this?');
+                        return confirmChange;
+                      },
                     ),
                     SwitchSettingsTile(
                       leading: Icon(Icons.usb),
@@ -96,6 +117,12 @@ class _AppSettingsState extends State<AppSettings> {
                       title: 'USB Debugging',
                       onChange: (value) {
                         debugPrint('USB Debugging: $value');
+                      },
+                      confirmChangeCallback: () async {
+                        var confirmChange = await showConfirmationDialog(
+                          context: context,
+                        );
+                        return confirmChange;
                       },
                     ),
                   ],
@@ -361,4 +388,41 @@ class _AppSettingsState extends State<AppSettings> {
       ),
     );
   }
+}
+
+Future<bool> showConfirmationDialog({
+  BuildContext context,
+  String confirmationMessage,
+  String okButtonText,
+  String cancelButtonText,
+}) {
+  confirmationMessage ??= 'Please confirm the change';
+  cancelButtonText ??= MaterialLocalizations
+      .of(context)
+      .cancelButtonLabel;
+  okButtonText ??= MaterialLocalizations
+      .of(context)
+      .okButtonLabel;
+  return showDialog(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        content: Text(confirmationMessage),
+        actions: [
+          FlatButton(
+            child: Text(cancelButtonText.toUpperCase()),
+            onPressed: () {
+              Navigator.of(dialogContext).pop(false);
+            },
+          ),
+          FlatButton(
+            child: Text(okButtonText.toUpperCase()),
+            onPressed: () {
+              Navigator.of(dialogContext).pop(true);
+            },
+          )
+        ],
+      );
+    },
+  );
 }

--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -23,7 +23,20 @@ typedef OnChanged<T> = void Function(T);
 /// widget is to be closed or not.
 ///
 /// if true, the widget will be closed
+@Deprecated(
+    'Use OnConfirmCallback which allows doing async processes while making a decision'
+    'This callback will be removed soon from the widgets that are using this')
 typedef OnConfirmedCallback = bool Function();
+
+/// This function type is used for verifying that the dialog/modal
+/// widget is to be closed or not.
+///
+/// if true, the widget will be closed
+///
+/// This callback should also support async operations like
+/// waiting for confirmation from user or any other asynchronous waiting
+/// which is why it returns Future of bool instead of just boolean
+typedef OnConfirmCallback = Future<bool> Function();
 
 /// This class behaves as a bridge between the settings screen widgets and the
 /// underlying storage mechanism.


### PR DESCRIPTION
Add confirmation callback to confirm changes before applying them in the preference/storage

Updated example accordingly

Signed-off-by: Harshvardhan Joshi <hj2931996@gmail.com>