### PR TITLE
Add keyboardType parameter (type TextInputType) to TextInputSettingsTile.

### DIFF
--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -1147,7 +1147,7 @@ class TextInputSettingsTile extends StatefulWidget {
   /// or input is not passed through the validation
   final Color errorColor;
 
-  /// [KeyboardType] of the [TextFormField]
+  /// [TextInputType] of the [TextFormField] to set the keyboard type to name, phone, etc.
   final TextInputType keyboardType;
 
   TextInputSettingsTile({

--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -1165,7 +1165,7 @@ class TextInputSettingsTile extends StatefulWidget {
     this.obscureText = false,
     this.borderColor,
     this.errorColor,
-    this.keyboardType = TextInputType.text,
+    this.keyboardType,
   }) : assert(
   autoValidate == false ||
       autoValidate == true && autoValidateMode == null,
@@ -1227,7 +1227,7 @@ class _TextInputSettingsTileState extends State<TextInputSettingsTile> {
           validator: widget.enabled ? widget.validator : null,
           onSaved: widget.enabled ? (value) => _onSave(value, onChanged) : null,
           obscureText: widget.obscureText,
-          keyboardType: widget.keyboardType??TextInputType.text,
+          keyboardType: widget.keyboardType,
           decoration: InputDecoration(
               errorStyle: TextStyle(
                 color: widget.errorColor ?? Colors.red,

--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -1147,6 +1147,9 @@ class TextInputSettingsTile extends StatefulWidget {
   /// or input is not passed through the validation
   final Color errorColor;
 
+  /// [KeyboardType] of the [TextFormField]
+  final TextInputType keyboardType;
+
   TextInputSettingsTile({
     @required this.title,
     @required this.settingKey,
@@ -1162,6 +1165,7 @@ class TextInputSettingsTile extends StatefulWidget {
     this.obscureText = false,
     this.borderColor,
     this.errorColor,
+    this.keyboardType = TextInputType.text,
   }) : assert(
   autoValidate == false ||
       autoValidate == true && autoValidateMode == null,
@@ -1223,6 +1227,7 @@ class _TextInputSettingsTileState extends State<TextInputSettingsTile> {
           validator: widget.enabled ? widget.validator : null,
           onSaved: widget.enabled ? (value) => _onSave(value, onChanged) : null,
           obscureText: widget.obscureText,
+          keyboardType: widget.keyboardType??TextInputType.text,
           decoration: InputDecoration(
               errorStyle: TextStyle(
                 color: widget.errorColor ?? Colors.red,


### PR DESCRIPTION
Very convenient to be able to use the keyboard types like name, phone, etc.