### PR TITLE
Fix bug with SettingsGroup subtitle

### DIFF
--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -362,7 +362,7 @@ class SettingsGroup extends StatelessWidget {
       ),
     ];
 
-    if (subtitle != null) {
+    if (subtitle.isNotEmpty) {
       elements.addAll([
         Container(
           padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
I've been testing the library from the null-safety branch, and I found a small bug where the SettingsGroup subtitle was added even when empty (since it's never null now).

I'm not sure if it's OK to pull request from a fork to a branch other than master in the base repository, so feel free to close this and make the change on your end if you prefer. Thanks!