### PR TITLE
Add support for custom title text styles for simple tiles.

### DIFF
--- a/lib/src/widgets/base_widgets.dart
+++ b/lib/src/widgets/base_widgets.dart
@@ -109,6 +109,12 @@ class _SettingsTile extends StatefulWidget {
   /// subtitle string for the tile
   final String? subtitle;
 
+  /// title text style
+  final TextStyle? titleTextStyle;
+
+  /// subtitle text style
+  final TextStyle? subtitleTextStyle;
+
   /// flag to represent if the tile is accessible or not, if false user input is ignored
   final bool enabled;
 
@@ -125,6 +131,8 @@ class _SettingsTile extends StatefulWidget {
     required this.title,
     required this.child,
     this.subtitle = '',
+    this.titleTextStyle,
+    this.subtitleTextStyle,
     this.onTap,
     this.enabled = true,
     this.showChildBelow = false,
@@ -151,13 +159,14 @@ class __SettingsTileState extends State<_SettingsTile> {
             leading: widget.leading,
             title: Text(
               widget.title,
-              style: headerTextStyle(context),
+              style: widget.titleTextStyle ?? headerTextStyle(context),
             ),
             subtitle: widget.subtitle!.isEmpty
                 ? null
                 : Text(
                     widget.subtitle!,
-                    style: subtitleTextStyle(context),
+                    style:
+                        widget.subtitleTextStyle ?? subtitleTextStyle(context),
                   ),
             enabled: widget.enabled,
             onTap: widget.onTap,

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -36,6 +36,12 @@ class SimpleSettingsTile extends StatelessWidget {
   /// subtitle string for the tile
   final String? subtitle;
 
+  /// title text style
+  final TextStyle? titleTextStyle;
+
+  /// subtitle text style
+  final TextStyle? subtitleTextStyle;
+
   /// widget to be placed at first in the tile
   final Widget? leading;
 
@@ -51,6 +57,8 @@ class SimpleSettingsTile extends StatelessWidget {
   SimpleSettingsTile({
     required this.title,
     this.subtitle,
+    this.titleTextStyle,
+    this.subtitleTextStyle,
     this.child,
     this.enabled = true,
     this.leading,
@@ -63,6 +71,8 @@ class SimpleSettingsTile extends StatelessWidget {
       leading: leading,
       title: title,
       subtitle: subtitle,
+      titleTextStyle: titleTextStyle,
+      subtitleTextStyle: subtitleTextStyle,
       enabled: enabled,
       onTap: () => _handleTap(context),
       child: child != null ? getIcon(context) : Text(''),


### PR DESCRIPTION
Simple PR to allow custom text styles.

<img width="337" alt="text_styles" src="https://user-images.githubusercontent.com/602268/135556483-cb3e1d8a-2bff-4db1-b912-f69e6463b34e.png">

Right now I just added it to simple tiles, but it can easily be added to other widgets as needed.

