### PR TITLE
fix example code stating parameter as `screen` instead of `child` as …

### DIFF
--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -18,7 +18,7 @@ part 'base_widgets.dart';
 /// SimpleSettingsTile(
 ///   title: 'Advanced',
 ///   subtitle: 'More, advanced settings.'
-///   screen: SettingsScreen(
+///   child: SettingsScreen(
 ///     title: 'Sub menu',
 ///     children: <Widget>[
 ///       CheckboxSettingsTile(


### PR DESCRIPTION
Fix for issue #64 