### PR TITLE
Add flag to enable textfield content to be autoselected on focus

### DIFF
--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -518,6 +518,9 @@ class TextInputSettingsTile extends StatefulWidget {
   /// in focus by default, default = true
   final bool autoFocus;
 
+  /// flag which represents if the text will be automatically selected on focus
+  final bool selectAllOnFocus;
+
   /// on change callback for handling the value change
   final OnChanged<String>? onChange;
 
@@ -545,6 +548,7 @@ class TextInputSettingsTile extends StatefulWidget {
     this.enabled = true,
     this.autoValidateMode = AutovalidateMode.onUserInteraction,
     this.autoFocus = true,
+    this.selectAllOnFocus = false,
     this.onChange,
     this.validator,
     this.obscureText = false,
@@ -569,6 +573,11 @@ class _TextInputSettingsTileState extends State<TextInputSettingsTile> {
     super.initState();
     _controller = TextEditingController();
     _focusNode = FocusNode();
+    _focusNode.addListener(() {
+      if (widget.selectAllOnFocus) {
+        _controller.selection = TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
This PR adds a selectAllOnFocus flag to the textfield tile to enable selecting all of the existing text automatically on focus.

The idea is to enable the user to quickly change the text without having to select everything. This is helpful for example when inputting short number sequences. In my case specifically, I want the user to input a number of minutes. Since the input is so short (1-2 keystrokes), it's easiest to just type in the new number than to edit what's already there.

Android has something similar which I named this flag after: https://developer.android.com/reference/android/widget/TextView#attr_android:selectAllOnFocus

Let me know what you think!