### PR TITLE
Bugfix for ValueChangeObserver.dispose()

### DIFF
--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -212,7 +212,7 @@ class _ValueChangeObserverState<T> extends State<ValueChangeObserver<T>> {
   @override
   void dispose() {
     super.dispose();
-    _notifiers.clear();
+    _notifiers.remove(cacheKey);
   }
 
   @override


### PR DESCRIPTION
We were accidentally deleting the whole _notifier map rather than just the specific cacheKey.

Effect was apparent when dealing with childrenIfEnabled blocks, where upon hiding them, dispose() was being called deleting all the notifiers for all the other keys.