### PR TITLE
TextInput: expose helperText and inputFormatters

### DIFF
--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_settings_screens/src/utils/widget_utils.dart';
 
@@ -541,6 +542,12 @@ class TextInputSettingsTile extends StatefulWidget {
   /// [TextInputType] of the [TextFormField] to set the keyboard type to name, phone, etc.
   final TextInputType? keyboardType;
 
+  /// form helper text
+  final String? helperText;
+
+  /// list of inputFormatters
+  final List<TextInputFormatter>? inputFormatters;
+
   TextInputSettingsTile({
     required this.title,
     required this.settingKey,
@@ -557,6 +564,8 @@ class TextInputSettingsTile extends StatefulWidget {
     this.keyboardType,
     this.titleTextStyle,
     this.subtitleTextStyle,
+    this.helperText,
+    this.inputFormatters,
   });
 
   @override
@@ -627,32 +636,37 @@ class _TextInputSettingsTileState extends State<TextInputSettingsTile> {
           obscureText: widget.obscureText,
           keyboardType: widget.keyboardType,
           cursorColor: borderColor,
+          inputFormatters: widget.inputFormatters ?? [],
           decoration: InputDecoration(
-              errorStyle: TextStyle(
-                color: errorColor,
+            helperText: widget.helperText,
+            errorMaxLines: 3,
+            helperMaxLines: 3,
+            errorStyle: TextStyle(
+              color: errorColor,
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.all(
+                Radius.circular(5.0),
               ),
-              errorBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.all(
-                  Radius.circular(5.0),
-                ),
-                borderSide: BorderSide(color: errorColor),
+              borderSide: BorderSide(color: errorColor),
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.all(
+                Radius.circular(5.0),
               ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.all(
-                  Radius.circular(5.0),
-                ),
-                borderSide: BorderSide(
-                  color: borderColor,
-                ),
+              borderSide: BorderSide(
+                color: borderColor,
               ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.all(
-                  Radius.circular(5.0),
-                ),
-                borderSide: BorderSide(
-                  color: borderColor,
-                ),
-              )),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.all(
+                Radius.circular(5.0),
+              ),
+              borderSide: BorderSide(
+                color: borderColor,
+              ),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
These seem to be very useful parameters. HelperText shows up next to the textfield popup and is great for documenting what the user should be inputting, without wasting space in the tile itself. InputFormatters allow even more control than validator functions and can be used to automatically filter unwanted characters so that they can't be typed altogether. The services.dart import is required for the inputformatters type.

Also adding errorMaxLines and helperMaxLines values so that these texts can wrap properly. The default otherwise is one line only and will cut off text if it doesn't fit in one line. 3 seems like a sane value but it could easily be higher. The popup will then expand vertically to fit more lines if required.