### PR TITLE
Slider units

### DIFF
--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -25,6 +25,10 @@ typedef OnChanged<T> = void Function(T);
 /// if true, the widget will be closed
 typedef OnConfirmedCallback = bool Function();
 
+/// This function type is used for callbacks which format a value
+/// and return a string. 
+typedef OnFormatterCallback<T> = String Function(T);
+
 /// This class behaves as a bridge between the settings screen widgets and the
 /// underlying storage mechanism.
 ///

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1393,6 +1393,9 @@ class SliderSettingsTile extends StatefulWidget {
   /// subtitle for the settings tile, default = ''
   final String subtitle;
 
+  /// units to append to value for in semantics, default = ''
+  final String units;
+
   /// title text style
   final TextStyle? titleTextStyle;
 
@@ -1439,6 +1442,11 @@ class SliderSettingsTile extends StatefulWidget {
 
   /// callback for fetching the value slider movement ends
   final OnChanged<double>? onChangeEnd;
+
+  /// callback used to create a subtitle from a slider value.  This allows
+  /// for complete customization of value formatting (as opposed to just setting
+  /// the [decimalPrecision]).
+  final OnFormatterCallback? subtitleFormatterCallback;
 
   /// callback for fetching the value slider movement starts
   final Widget? leading;
@@ -1493,6 +1501,8 @@ class SliderSettingsTile extends StatefulWidget {
     this.decimalPrecision = 2,
     this.titleTextStyle,
     this.subtitleTextStyle,
+    this.units = '',
+    this.subtitleFormatterCallback,
   });
 
   @override
@@ -1519,7 +1529,8 @@ class _SliderSettingsTileState extends State<SliderSettingsTile> {
           children: <Widget>[
             _SimpleHeaderTile(
               title: widget.title,
-              subtitle: widget.subtitle.isNotEmpty ? widget.subtitle : value.toStringAsFixed(widget.decimalPrecision),
+              subtitle: widget.subtitle.isNotEmpty ? widget.subtitle :
+                    (widget.units.isNotEmpty ? _handleSubtitleFormatterCallback(value)+widget.units : _handleSubtitleFormatterCallback(value)),
               leading: widget.leading,
               titleTextStyle: widget.titleTextStyle,
               subtitleTextStyle: widget.subtitleTextStyle,
@@ -1560,6 +1571,10 @@ class _SliderSettingsTileState extends State<SliderSettingsTile> {
   Future<void> _handleSliderChangeEnd(double newValue, OnChanged<double> onChanged) async {
     _updateWidget(newValue, onChanged);
     widget.onChangeEnd?.call(newValue);
+  }
+
+  String _handleSubtitleFormatterCallback(double newValue) {
+    return widget.subtitleFormatterCallback!=null ? widget.subtitleFormatterCallback!.call(newValue) : newValue.toStringAsFixed(widget.decimalPrecision);
   }
 }
 

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1446,7 +1446,7 @@ class SliderSettingsTile extends StatefulWidget {
   /// callback used to create a subtitle from a slider value.  This allows
   /// for complete customization of value formatting (as opposed to just setting
   /// the [decimalPrecision]).
-  final OnFormatterCallback? subtitleFormatterCallback;
+  final OnFormatterCallback<double>? subtitleFormatterCallback;
 
   /// callback for fetching the value slider movement starts
   final Widget? leading;


### PR DESCRIPTION
This PR allows for 2 options to the `SliderSettingsTile`.
It allows simply adding a `units` string that is appended to the value,
and also adds a additional option of using a `subtitleFormatterCallback` for complete control of how the value is formatted and presented to the user.