### PR TITLE
Dropdown with widgets

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,0 +1,14 @@
+//
+//  Generated file. Do not edit.
+//
+
+import FlutterMacOS
+import Foundation
+
+import path_provider_foundation
+import shared_preferences_foundation
+
+func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+}

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1260,8 +1260,8 @@ class DropDownSettingsTile<T> extends StatefulWidget {
   /// Selected value in the radio button group otherwise known as group value
   final T selected;
 
-  /// A map containing unique values along with the display name
-  final Map<T, String> values;
+  /// A map containing unique values which could use a String of a Widget as the display value
+  final Map<T, dynamic> values;
 
   /// title for the settings tile
   final String title;
@@ -1341,7 +1341,9 @@ class _DropDownSettingsTileState<T> extends State<DropDownSettingsTile<T>> {
                 onChanged: (newValue) => _handleDropDownChange(newValue, onChanged),
                 enabled: widget.enabled,
                 itemBuilder: (T value) {
-                  return Text(widget.values[value]!);
+                  var val = widget.values[value]!;
+                  if(val is String) return Text(val);
+                  return val;
                 },
               ),
             )

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1260,7 +1260,7 @@ class DropDownSettingsTile<T> extends StatefulWidget {
   /// Selected value in the radio button group otherwise known as group value
   final T selected;
 
-  /// A map containing unique values which could use a String of a Widget as the display value
+  /// A map containing unique values which could use a String or a Widget as the display value
   final Map<T, dynamic> values;
 
   /// title for the settings tile


### PR DESCRIPTION
Allow the use of widgets for `DropDownSettingsTile()` for the `value` property. Useful for scenarios such as displaying a theme selector where you'd like to show the theme color and the theme name using a `Row()` widget.

Still supports the use of `String` only values where it defaults to the use of `Text()`