### PR TITLE
Fix: active color

### DIFF
--- a/lib/src/widgets/base_widgets.dart
+++ b/lib/src/widgets/base_widgets.dart
@@ -720,6 +720,7 @@ class _SettingsSlider extends StatelessWidget {
   final bool eagerUpdate;
 
   final Color? activeColor;
+  final Color? inActiveColor;
 
   const _SettingsSlider({
     required this.value,
@@ -728,6 +729,7 @@ class _SettingsSlider extends StatelessWidget {
     required this.step,
     required this.enabled,
     required this.activeColor,
+    required this.inActiveColor,
     this.onChangeStart,
     this.onChanged,
     this.onChangeEnd,
@@ -748,6 +750,7 @@ class _SettingsSlider extends StatelessWidget {
       onChangeEnd:
           enabled && !eagerUpdate ? (value) => onChangeEnd?.call(value) : null,
       activeColor: activeColor,
+      inactiveColor: inActiveColor,
     );
   }
 }

--- a/lib/src/widgets/base_widgets.dart
+++ b/lib/src/widgets/base_widgets.dart
@@ -589,9 +589,7 @@ class _SettingsSwitch extends StatelessWidget {
     return Switch.adaptive(
       value: value,
       onChanged: enabled ? onChanged : null,
-      thumbColor: MaterialStateProperty.all(
-          activeColor ?? Theme.of(context).colorScheme.primary),
-      inactiveThumbColor: Theme.of(context).colorScheme.secondary,
+      activeColor: activeColor ?? Theme.of(context).colorScheme.secondary,
     );
   }
 }
@@ -721,12 +719,15 @@ class _SettingsSlider extends StatelessWidget {
   /// ignored & will not be executed
   final bool eagerUpdate;
 
+  final Color? activeColor;
+
   const _SettingsSlider({
     required this.value,
     required this.min,
     required this.max,
     required this.step,
     required this.enabled,
+    required this.activeColor,
     this.onChangeStart,
     this.onChanged,
     this.onChangeEnd,
@@ -746,6 +747,7 @@ class _SettingsSlider extends StatelessWidget {
       onChanged: enabled ? (value) => onChanged?.call(value) : null,
       onChangeEnd:
           enabled && !eagerUpdate ? (value) => onChangeEnd?.call(value) : null,
+      activeColor: activeColor,
     );
   }
 }

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1497,6 +1497,8 @@ class SliderSettingsTile extends StatefulWidget {
   ///     display value: 5.25
   final int decimalPrecision;
 
+  final Color? activeColor;
+
   const SliderSettingsTile({
     super.key,
     required this.title,
@@ -1515,6 +1517,7 @@ class SliderSettingsTile extends StatefulWidget {
     this.decimalPrecision = 2,
     this.titleTextStyle,
     this.subtitleTextStyle,
+    this.activeColor,
   });
 
   @override
@@ -1562,6 +1565,7 @@ class _SliderSettingsTileState extends State<SliderSettingsTile> {
               max: widget.max,
               min: widget.min,
               step: widget.step,
+              activeColor: widget.activeColor,
             ),
             _SettingsTileDivider(),
           ],
@@ -1946,6 +1950,8 @@ class SliderModalSettingsTile extends StatefulWidget {
   /// callback for fetching the value slider movement ends
   final OnChanged<double>? onChangeEnd;
 
+  final Color? activeColor;
+
   const SliderModalSettingsTile({
     super.key,
     required this.title,
@@ -1963,6 +1969,7 @@ class SliderModalSettingsTile extends StatefulWidget {
     this.eagerUpdate = true,
     this.titleTextStyle,
     this.subtitleTextStyle,
+    this.activeColor,
   });
 
   @override
@@ -2011,6 +2018,7 @@ class _SliderModalSettingsTileState extends State<SliderModalSettingsTile> {
                   max: widget.max,
                   min: widget.min,
                   step: widget.step,
+                  activeColor: widget.activeColor,
                 )
               ],
             ),

--- a/lib/src/widgets/settings_widgets.dart
+++ b/lib/src/widgets/settings_widgets.dart
@@ -1497,7 +1497,10 @@ class SliderSettingsTile extends StatefulWidget {
   ///     display value: 5.25
   final int decimalPrecision;
 
+  final bool showDivider;
+
   final Color? activeColor;
+  final Color? inActiveColor;
 
   const SliderSettingsTile({
     super.key,
@@ -1518,6 +1521,8 @@ class SliderSettingsTile extends StatefulWidget {
     this.titleTextStyle,
     this.subtitleTextStyle,
     this.activeColor,
+    this.inActiveColor,
+    this.showDivider = true,
   });
 
   @override
@@ -1566,8 +1571,9 @@ class _SliderSettingsTileState extends State<SliderSettingsTile> {
               min: widget.min,
               step: widget.step,
               activeColor: widget.activeColor,
+              inActiveColor: widget.inActiveColor,
             ),
-            _SettingsTileDivider(),
+            if (widget.showDivider) _SettingsTileDivider(),
           ],
         );
       },
@@ -1951,6 +1957,7 @@ class SliderModalSettingsTile extends StatefulWidget {
   final OnChanged<double>? onChangeEnd;
 
   final Color? activeColor;
+  final Color? inActiveColor;
 
   const SliderModalSettingsTile({
     super.key,
@@ -1970,6 +1977,7 @@ class SliderModalSettingsTile extends StatefulWidget {
     this.titleTextStyle,
     this.subtitleTextStyle,
     this.activeColor,
+    this.inActiveColor,
   });
 
   @override
@@ -2019,6 +2027,7 @@ class _SliderModalSettingsTileState extends State<SliderModalSettingsTile> {
                   min: widget.min,
                   step: widget.step,
                   activeColor: widget.activeColor,
+                  inActiveColor: widget.inActiveColor,
                 )
               ],
             ),


### PR DESCRIPTION
In Switch.adaptive for inactiveThumbColor: **"If thumbColor returns a non-null color in the default state, it will be used instead of this color."**

thumbColor was always non-null, so the switch has always the same color even when disabled and enabled - bad design. thumbColor need more complex setting, check the Switch.adaptive docs. 

This change appeared in the last month update. I suggest to go back to the old solution and remove this and use just activeColor, which is optional, otherwise Theme.of(context).colorScheme.secondary would be used.

I also added for the user optional properties: **active/inactive color** and **showDivider** in Slider. All these changes are **not breaking.**